### PR TITLE
docs: restore Single Persona MVP designation for PRD consistency

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2,7 +2,7 @@
 
 Author: digital-twin-team2  
 Version: 1.0 (2026-01-25)  
-Project: Digital Twin — Personal AI Agent 
+Project: Digital Twin — Personal AI Agent (Single Persona MVP)
 
 This document is an implementation-ready technical design for a "Personal AI Agent" (Single Persona MVP) built with Next.js (App Router), TypeScript, Vercel AI SDK, and Upstash Vector. It defines the RAG pipeline, Upstash vector schema, MCP (Model Context Protocol) tools, frontend component architecture, and the API contract required for Week 2 deliverables. This design deliberately uses a generic persona ("Subject") appropriate for a team project (no real individual's name or identifying personal data).
 


### PR DESCRIPTION
Address reviewer feedback from PR #6 to maintain consistency with PRD and Week 2 scope documentation.

## Changes
- Restored "(Single Persona MVP)" designation to Project line in design.md (line 4)

## Context
This ensures the design document header matches the PRD and Week 2 scope definitions, as noted by @rohan251sh in PR #6 review.

Fixes consistency issue raised in PR #6 @rohan251sh @PrabhavSrst @momo23546842 